### PR TITLE
各リンクのレイアウトを変更する #44

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -84,8 +84,11 @@ body {
 }
 
 hr {
+  border: 0;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
   box-sizing: content-box;
   height: 0;
+  margin: 0;
   overflow: visible;
 }
 
@@ -126,19 +129,20 @@ a {
   color: #007bff;
   text-decoration: none;
   background-color: transparent;
-}
-a:hover {
-  color: #0056b3;
-  text-decoration: underline;
-}
+  display: block;
+  &:hover {
+    color: #0056b3;
+    text-decoration: underline;
+  }
 
-a:not([href]):not([class]) {
-  color: inherit;
-  text-decoration: none;
-}
-a:not([href]):not([class]):hover {
-  color: inherit;
-  text-decoration: none;
+  &:not([href]):not([class]) {
+    color: inherit;
+    text-decoration: none;
+  }
+  &:not([href]):not([class]):hover {
+    color: inherit;
+    text-decoration: none;
+  }
 }
 
 img {
@@ -246,13 +250,6 @@ h1,
   font-weight: 300;
 }
 
-hr {
-  margin-top: 1rem;
-  margin-bottom: 1rem;
-  border: 0;
-  border-top: 1px solid rgba(0, 0, 0, 0.1);
-}
-
 small,
 .small {
   font-size: 80%;
@@ -262,6 +259,17 @@ small,
 .pre-scrollable {
   max-height: 340px;
   overflow-y: scroll;
+}
+
+.prefectures {
+  a {
+    font-weight: bold;
+    padding: 12px;
+    &:hover{
+      background-color: #e7efff;
+      text-decoration: none;
+    }
+  }
 }
 
 .container,
@@ -1437,6 +1445,19 @@ fieldset:disabled a.btn {
   pointer-events: none;
 }
 
+.btn-outline-primary {
+  border-color: var(--primary);
+  font-weight: bold;
+  &:hover{
+    color: #fff;
+    background-color: #192bc2;
+    a{
+      color: #fff;
+      text-decoration: none;
+    }
+  }
+}
+
 .btn-outline-light {
   color: #f8f9fa;
   border-color: #f8f9fa;
@@ -1686,16 +1707,23 @@ input[type="button"].btn-block {
   clear: both;
   font-weight: 400;
   color: #fff;
-  text-align: inherit;
+  text-align: center;
   white-space: nowrap;
   background-color: #192bc2;
   border: 0;
 }
-.dropdown-item:hover,
+.dropdown-item{
+  background-color: #192bc2 !important;
+  a {
+    &:hover{
+      color: var(--dark);
+      text-decoration: none;
+    }
+  }
+}
+
 .dropdown-item:focus {
-  color: #16181b;
   text-decoration: none;
-  background-color: #1c2fd9;
 }
 
 .dropdown-header {
@@ -2184,7 +2212,9 @@ input[type="button"].btn-block {
 }
 .navbar-brand:hover,
 .navbar-brand:focus {
-  text-decoration: none;
+  a{
+    text-decoration: none;
+  }
 }
 
 .navbar-nav {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -183,7 +183,9 @@ module ApplicationHelper
 
     def string_output(prefecture)
       tag.hr do
-        tag.li { tag.a(prefecture.name, href: "/prefectures/#{prefecture.id}") }
+        content_tag(:li, class:'prefectures') do
+          tag.a(prefecture.name, href: "/prefectures/#{prefecture.id}")
+        end
       end
     end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,7 +11,7 @@
 		<div class="collapse navbar-collapse" id="navbarResponsive">
 			<ul class="navbar-nav ml-auto">
 				<li class="nav-item dropdown py-2">
-					<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
+					<a class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
 						aria-expanded="false">
 						北海道・東北
 					</a>
@@ -20,7 +20,7 @@
 					</ul>
 				</li>
 				<li class="nav-item dropdown py-2">
-					<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
+					<a class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
 						aria-expanded="false">
 						関東
 					</a>
@@ -29,7 +29,7 @@
 					</ul>
 				</li>
 				<li class="nav-item dropdown py-2">
-					<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
+					<a class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
 						aria-expanded="false">
 						中部
 					</a>
@@ -38,7 +38,7 @@
 					</ul>
 				</li>
 				<li class="nav-item dropdown py-2">
-					<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
+					<a class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
 						aria-expanded="false">
 						近畿
 					</a>
@@ -47,7 +47,7 @@
 					</ul>
 				</li>
 				<li class="nav-item dropdown py-2">
-					<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
+					<a class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
 						aria-expanded="false">
 						中国
 					</a>
@@ -56,7 +56,7 @@
 					</ul>
 				</li>
 				<li class="nav-item dropdown py-2">
-					<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
+					<a class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
 						aria-expanded="false">
 						四国
 					</a>
@@ -65,7 +65,7 @@
 					</ul>
 				</li>
 				<li class="nav-item dropdown py-2">
-					<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
+					<a class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
 						aria-expanded="false">
 						九州
 					</a>

--- a/app/views/prefectures/show.html.erb
+++ b/app/views/prefectures/show.html.erb
@@ -36,4 +36,8 @@
 	</div>
 </div>
 
-<div> <%= link_to '戻る', prefectures_path %> </div>
+<div class="btn btn-outline-primary m-3">
+	<%= link_to prefectures_path do%>
+	<i class="fas fa-angle-left"></i> 戻る
+	<% end %>
+</div>


### PR DESCRIPTION
- ヘッダーメニューのドロップダウンメニューのレイアウト変更
- ヘッダーのロゴリンクのホバー時の下線を消去
- 戻るリンクを戻るボタンに変更
- 都道府県一覧リンクのホバー時のレイアウト変更