### PR TITLE
レスポンシブ時のヘッダーメニュー修正 #48

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -183,7 +183,7 @@ module ApplicationHelper
 
     def string_output(prefecture)
       tag.hr do
-        content_tag(:li, class:'prefectures') do
+        tag.li(class: 'prefectures') do
           tag.a(prefecture.name, href: "/prefectures/#{prefecture.id}")
         end
       end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,9 +3,9 @@
 	<div class="container">
 		<div class="navbar-brand js-scroll-trigger"> <%= link_to 'お天気 History', root_path %> </div>
 		<button class="navbar-toggler navbar-toggler-right text-uppercase font-weight-bold bg-primary text-white rounded"
-			type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive"
+			type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive"
 			aria-expanded="false" aria-label="Toggle navigation">
-			Menu
+			MENU
 			<i class="fas fa-bars"></i>
 		</button>
 		<div class="collapse navbar-collapse" id="navbarResponsive">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,8 +17,8 @@
   <%= yield %>
   <%= render 'layouts/footer' %>
   <!-- Option 1: Bootstrap Bundle with Popper -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-ygbV9kiqUc6oa4msXn9868pTtWMgiQaeYH7/t7LECLbyPA2x65Kgf80OJFdroafW" crossorigin="anonymous">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-b5kHyXgcpbZJO/tY9Ul7kGkf1S0CWuKcCD38l8YkeH8z8QjE0GmW1gYU5S9FOnJ0" crossorigin="anonymous">
   </script>
 </body>
 

--- a/spec/features/prefectures_spec.rb
+++ b/spec/features/prefectures_spec.rb
@@ -14,10 +14,7 @@ RSpec.describe 'Prefectures' do
 
     it 'get index area categories name' do
       visit prefectures_path
-      expect(page).to have_selector(
-        'div.accordion-button',
-        text: '北海道・東北'
-      )
+      expect(page).to have_selector('div.accordion-button', text: '北海道・東北')
       expect(page).to have_selector('div.accordion-button', text: '関東')
       expect(page).to have_selector('div.accordion-button', text: '中部')
       expect(page).to have_selector('div.accordion-button', text: '近畿')
@@ -60,6 +57,13 @@ RSpec.describe 'Prefectures' do
     it 'get header' do
       visit prefectures_path
       expect(page).to have_css('.navbar')
+    end
+
+    it 'click header responsive menu' do
+      visit prefectures_path
+      expect(find('.navbar-toggler', visible: false)).to have_content('MENU')
+      click_button 'MENU'
+      expect(find('.nav-link', match: :first, visible: false)).to have_content('北海道・東北')
     end
 
     it 'get footer' do


### PR DESCRIPTION
- Bootstrap4系ではなく、5系のdata-bs-toggleとdata-bs-targetに修正
- Bootstrap JavaScript pluginをbeta1からbeta2に修正
- responsive menuのfeaturesテスト作成