### PR TITLE
過去ログのレイアウト変更 #58

### DIFF
--- a/app/controllers/prefectures_controller.rb
+++ b/app/controllers/prefectures_controller.rb
@@ -13,6 +13,10 @@ class PrefecturesController < ApplicationController
     prefecture.divide_monthly
   end
 
+  def archives_year
+    prefecture.divide_year
+  end
+
   def archives
     prefecture.weather_apis.where(dated_on: year_monthly)
   end

--- a/app/helpers/prefectures_helper.rb
+++ b/app/helpers/prefectures_helper.rb
@@ -5,6 +5,8 @@ module PrefecturesHelper
 
   delegate :archives_link, to: :controller
 
+  delegate :archives_year, to: :controller
+
   delegate :archives, to: :controller
 
   def prefecture

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -11,4 +11,11 @@ class City < ApplicationRecord
   # group_byメソッドで、各々のtimezoneをstrftimeでフォーマット変換して上でグループ化を実行
   # mapメソッドでそれぞれの時期キーごとに要素をカウントアップしたhashを作成
   # sortを実行
+
+  def divide_year
+    days_group = weather_apis.pluck(:created_at).group_by do |timezone|
+      timezone.strftime('%Y')
+    end
+    days_group.map { |k, v| [k, v] }.sort.reverse
+  end
 end

--- a/app/views/prefectures/_archives.html.erb
+++ b/app/views/prefectures/_archives.html.erb
@@ -1,8 +1,39 @@
-<div>
-<h6 class="font-italic">過去ログ</h6>
-<ul>
-	<% archives_link.each do |yyyymm, count| %>
-	<li><%= link_to ymconv(yyyymm, count.to_s), prefecture_archive_path(prefecture, yyyymm) %></li>
-	<% end %>
-</ul>
+<div class="container-fluid mb-4">
+	<div class="accordion" id="accordionExample">
+		<!-- Log List -->
+		<div class="accordion-item">
+			<button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseLog"
+				aria-expanded="false" aria-controls="collapseLog">
+				過去ログ
+			</button>
+		</div>
+		<div id="collapseLog" class="accordion-collapse collapse" aria-labelledby="headingLog">
+			<!-- Year List -->
+			<div class="accordion-item">
+				<% archives_year.each do |yyyymm, count| %>
+				<button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseYear"
+					aria-expanded="false" aria-controls="collapseYear">
+					<ul　class="m-0">
+						<li class="fw-bold"><%= ymconv(yyyymm, archives_link.size) %></li>
+					</ul>
+				</button>
+				<% end %>
+				<!-- Monthly List -->
+				<div id="collapseYear" class="accordion-collapse collapse" aria-labelledby="headingYear"
+					data-bs-parent="#accordionExample">
+					<div class="accordion-body">
+						<ul　class="m-0">
+							<% archives_link.each do |yyyymm, count| %>
+							<li class="p-3">
+								<%= link_to ymconv(yyyymm, count.to_s), prefecture_archive_path(prefecture, yyyymm) %>
+							</li>
+							<hr />
+							<% end %>
+							<hr />
+						</ul>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
 </div>

--- a/app/views/prefectures/_breadcrumb.html.erb
+++ b/app/views/prefectures/_breadcrumb.html.erb
@@ -1,7 +1,17 @@
 <div class="container-fluid">
 	<h1 class="mt-4"> <%=prefecture.name%> </h1>
 	<ol class="breadcrumb mb-4">
+			<!-- prefectures page -->
 		<li class="breadcrumb-item"><%= link_to '都道府県', prefectures_path %></li>
-		<li class="breadcrumb-item active"><%= link_to prefecture.name, prefecture_path%></li>
+				<!-- show page -->
+		<li class="breadcrumb-item"><%= link_to prefecture.name, prefecture_path%></li>
+				<!-- archive page -->
+		<li class="breadcrumb-item">
+			<% archives_link.each do |yyyymm, count| %>
+				<% if current_page?(prefecture_archive_path(prefecture, yyyymm)) %>
+					<%= link_to ymconv(yyyymm, count.to_s), prefecture_archive_path(prefecture, yyyymm) %>
+				<% end %>
+			<% end %>
+		</li>
 	</ol>
 </div>

--- a/spec/factories/cities.rb
+++ b/spec/factories/cities.rb
@@ -7,5 +7,11 @@ FactoryBot.define do
     trait :kanagawa do
       name { '神奈川県' }
     end
+
+    factory :city_with_weather_apis do
+      after(:create) do |city|
+        create_list(:weather_api, 3, city: city)
+      end
+    end
   end
 end

--- a/spec/features/prefectures_spec.rb
+++ b/spec/features/prefectures_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Prefectures' do
   let!(:city) { create(:city) }
-  let!(:weather_api) { FactoryBot.create(:weather_api) }
+  let!(:weather_api) { create(:weather_api, city: city) }
 
   before { create(:city, :kanagawa) }
 
@@ -91,6 +91,15 @@ RSpec.describe 'Prefectures' do
     it 'get footer' do
       visit prefectures_path
       expect(page).to have_css('.footer')
+    end
+  end
+
+  describe 'Display bread crumb' do
+    it 'bread crumb prefecture page' do
+      visit prefecture_path city.id
+      expect(page).to have_selector('li[class=breadcrumb-item]', text: '都道府県')
+      expect(page).to have_selector('li[class=breadcrumb-item]', text: '北海道')
+      expect(page).not_to have_selector('li[class=breadcrumb-item]', text: ymconv(weather_api.dated_on.strftime('%Y%m'), 1).to_s)
     end
   end
 end


### PR DESCRIPTION
- 過去ログを折りたたみメニューに変更
- 過去ログを西暦別にまとめる
- パンくずリストを修正
Closes #58 