### PR TITLE
アクセシビリティ修正 #98

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,7 +45,7 @@ ol,
 ul,
 dl {
   margin-top: 0;
-  margin-bottom: 1rem;
+  margin-bottom: 0;
   padding: 0;
 }
 
@@ -67,12 +67,13 @@ a {
   }
 }
 
-.prefectures {
+.accordion-body {
   a {
     font-weight: bold;
     padding: 12px;
     &:hover {
-      background-color: $light;
+      background-color: $main;
+      color: $light;
       text-decoration: none;
     }
   }
@@ -123,7 +124,6 @@ td.border-none {
 .dropdown-item {
   display: block;
   width: 100%;
-  padding: 1.5rem 1.5rem;
   clear: both;
   font-weight: 400;
   color: $white;
@@ -131,12 +131,11 @@ td.border-none {
   white-space: nowrap;
   background-color: $main;
   border: 0;
-}
-
-.dropdown-item {
-  background-color: $main !important;
   a {
+    font-weight: bold;
+    padding: 12px;
     &:hover {
+      background-color: $light;
       color: $dark;
       text-decoration: none;
     }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,7 @@
 class ApplicationController < ActionController::Base
+  include ApplicationHelper
+
+  def all_prefectures
+    City.all
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,91 +1,9 @@
 module ApplicationHelper
+  delegate :all_prefectures, to: :controller
+
   def full_title(page_title = '')
     base_title = 'お天気HISTORY'
     page_title.empty? ? base_title : "#{page_title} | #{base_title}"
-  end
-
-  def hokkaido_tohoku_area_link
-    prefectures = set_city
-    html_text = set_text
-    prefectures.each do |prefecture|
-      case prefecture.id
-      when hokkaido_tohoku_area_id?
-        html_text += string_output(prefecture)
-      end
-    end
-    raw(html_text)
-  end
-
-  def kanto_area_link
-    prefectures = set_city
-    html_text = set_text
-    prefectures.each do |prefecture|
-      case prefecture.id
-      when kanto_area_id
-        html_text += string_output(prefecture)
-      end
-    end
-    raw(html_text)
-  end
-
-  def chubu_area_link
-    prefectures = set_city
-    html_text = set_text
-    prefectures.each do |prefecture|
-      case prefecture.id
-      when chubu_area_id
-        html_text += string_output(prefecture)
-      end
-    end
-    raw(html_text)
-  end
-
-  def kinki_area_link
-    prefectures = set_city
-    html_text = set_text
-    prefectures.each do |prefecture|
-      case prefecture.id
-      when kinki_area_id
-        html_text += string_output(prefecture)
-      end
-    end
-    raw(html_text)
-  end
-
-  def chugoku_area_link
-    prefectures = set_city
-    html_text = set_text
-    prefectures.each do |prefecture|
-      case prefecture.id
-      when chugoku_area_id
-        html_text += string_output(prefecture)
-      end
-    end
-    raw(html_text)
-  end
-
-  def shikoku_area_link
-    prefectures = set_city
-    html_text = set_text
-    prefectures.each do |prefecture|
-      case prefecture.id
-      when shikoku_area_id
-        html_text += string_output(prefecture)
-      end
-    end
-    raw(html_text)
-  end
-
-  def kyushu_area_link
-    prefectures = set_city
-    html_text = set_text
-    prefectures.each do |prefecture|
-      case prefecture.id
-      when kyushu_area_id
-        html_text += string_output(prefecture)
-      end
-    end
-    raw(html_text)
   end
 
   def weather_color(color)
@@ -111,39 +29,39 @@ module ApplicationHelper
     "#{yyyymm}(#{cnt})"
   end
 
+  def area_id(range)
+    ->(id) { range.include? id }
+  end
+
+  def hokkaido_tohoku_area_id?
+    area_id(1..7)
+  end
+
+  def kanto_area_id
+    area_id(8..14)
+  end
+
+  def chubu_area_id
+    area_id(15..23)
+  end
+
+  def kinki_area_id
+    area_id(24..30)
+  end
+
+  def chugoku_area_id
+    area_id(31..35)
+  end
+
+  def shikoku_area_id
+    area_id(36..39)
+  end
+
+  def kyushu_area_id
+    area_id(40..47)
+  end
+
   private
-
-    def area_id(range)
-      ->(id) { range.include? id }
-    end
-
-    def hokkaido_tohoku_area_id?
-      area_id(1..7)
-    end
-
-    def kanto_area_id
-      area_id(8..14)
-    end
-
-    def chubu_area_id
-      area_id(15..23)
-    end
-
-    def kinki_area_id
-      area_id(24..30)
-    end
-
-    def chugoku_area_id
-      area_id(31..35)
-    end
-
-    def shikoku_area_id
-      area_id(36..39)
-    end
-
-    def kyushu_area_id
-      area_id(40..47)
-    end
 
     def weather_info(range)
       ->(weather_id) { range.include? weather_id }
@@ -175,21 +93,5 @@ module ApplicationHelper
 
     def clouds
       weather_info(801..804)
-    end
-
-    def set_city
-      City.all
-    end
-
-    def set_text
-      ''
-    end
-
-    def string_output(prefecture)
-      tag.hr do
-        tag.li(class: 'prefectures') do
-          tag.a(prefecture.name, href: "/prefectures/#{prefecture.id}")
-        end
-      end
     end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -10,67 +10,123 @@
 		</button>
 		<div class="collapse navbar-collapse" id="navbarResponsive">
 			<ul class="navbar-nav ml-auto">
+				<!-- 北海道・東北 Link一覧 -->
 				<li class="nav-item dropdown py-2">
 					<a class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
 						aria-expanded="false">
 						北海道・東北
 					</a>
 					<ul class="dropdown-menu" aria-labelledby="navbarDropdown">
-						<div class="dropdown-item"><%= hokkaido_tohoku_area_link %></div>
+						<% all_prefectures.each do |prefecture| %>
+						<% case prefecture.id
+								when hokkaido_tohoku_area_id? %>
+						<li class="dropdown-item">
+							<%= link_to prefecture.name, prefecture_path(prefecture) %>
+						</li>
+						<% end %>
+						<% end %>
 					</ul>
 				</li>
+				<!-- 関東 Link一覧 -->
 				<li class="nav-item dropdown py-2">
-					<a class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
+					<a class="nav-link dropdown-toggle" id="navbarDropdownTwo" role="button" data-bs-toggle="dropdown"
 						aria-expanded="false">
 						関東
 					</a>
-					<ul class="dropdown-menu" aria-labelledby="navbarDropdown">
-						<div class="dropdown-item"><%= kanto_area_link %></div>
+					<ul class="dropdown-menu" aria-labelledby="navbarDropdownTwo">
+						<% all_prefectures.each do |prefecture| %>
+						<% case prefecture.id
+								when kanto_area_id %>
+						<li class="dropdown-item">
+							<%= link_to prefecture.name, prefecture_path(prefecture) %>
+						</li>
+						<% end %>
+						<% end %>
 					</ul>
 				</li>
+				<!-- 中部 Link一覧 -->
 				<li class="nav-item dropdown py-2">
-					<a class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
+					<a class="nav-link dropdown-toggle" id="navbarDropdownThree" role="button" data-bs-toggle="dropdown"
 						aria-expanded="false">
 						中部
 					</a>
-					<ul class="dropdown-menu" aria-labelledby="navbarDropdown">
-						<div class="dropdown-item"><%= chubu_area_link %></div>
+					<ul class="dropdown-menu" aria-labelledby="navbarDropdownThree">
+						<% all_prefectures.each do |prefecture| %>
+						<% case prefecture.id
+								when chubu_area_id %>
+						<li class="dropdown-item">
+							<%= link_to prefecture.name, prefecture_path(prefecture) %>
+						</li>
+						<% end %>
+						<% end %>
 					</ul>
 				</li>
+				<!-- 近畿 Link一覧 -->
 				<li class="nav-item dropdown py-2">
-					<a class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
+					<a class="nav-link dropdown-toggle" id="navbarDropdownFour" role="button" data-bs-toggle="dropdown"
 						aria-expanded="false">
 						近畿
 					</a>
-					<ul class="dropdown-menu" aria-labelledby="navbarDropdown">
-						<div class="dropdown-item"><%= kinki_area_link %></div>
+					<ul class="dropdown-menu" aria-labelledby="navbarDropdownFour">
+						<% all_prefectures.each do |prefecture| %>
+						<% case prefecture.id
+								when kinki_area_id %>
+						<li class="dropdown-item">
+							<%= link_to prefecture.name, prefecture_path(prefecture) %>
+						</li>
+						<% end %>
+						<% end %>
 					</ul>
 				</li>
+				<!-- 中国 Link一覧 -->
 				<li class="nav-item dropdown py-2">
-					<a class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
+					<a class="nav-link dropdown-toggle" id="navbarDropdownFive" role="button" data-bs-toggle="dropdown"
 						aria-expanded="false">
 						中国
 					</a>
-					<ul class="dropdown-menu" aria-labelledby="navbarDropdown">
-						<div class="dropdown-item"><%= chugoku_area_link %></div>
+					<ul class="dropdown-menu" aria-labelledby="navbarDropdownFive">
+						<% all_prefectures.each do |prefecture| %>
+						<% case prefecture.id
+								when chugoku_area_id %>
+						<li class="dropdown-item">
+							<%= link_to prefecture.name, prefecture_path(prefecture) %>
+						</li>
+						<% end %>
+						<% end %>
 					</ul>
 				</li>
+				<!-- 四国 Link一覧 -->
 				<li class="nav-item dropdown py-2">
-					<a class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
+					<a class="nav-link dropdown-toggle" id="navbarDropdownSix" role="button" data-bs-toggle="dropdown"
 						aria-expanded="false">
 						四国
 					</a>
-					<ul class="dropdown-menu" aria-labelledby="navbarDropdown">
-						<div class="dropdown-item"><%= shikoku_area_link %></div>
+					<ul class="dropdown-menu" aria-labelledby="navbarDropdownSix">
+						<% all_prefectures.each do |prefecture| %>
+						<% case prefecture.id
+								when shikoku_area_id %>
+						<li class="dropdown-item">
+							<%= link_to prefecture.name, prefecture_path(prefecture) %>
+						</li>
+						<% end %>
+						<% end %>
 					</ul>
 				</li>
+				<!-- 九州・沖縄 Link一覧 -->
 				<li class="nav-item dropdown py-2">
-					<a class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
+					<a class="nav-link dropdown-toggle" id="navbarDropdownSeven" role="button" data-bs-toggle="dropdown"
 						aria-expanded="false">
 						九州
 					</a>
-					<ul class="dropdown-menu" aria-labelledby="navbarDropdown">
-						<div class="dropdown-item"><%= kyushu_area_link %></div>
+					<ul class="dropdown-menu" aria-labelledby="navbarDropdownSeven">
+						<% all_prefectures.each do |prefecture| %>
+						<% case prefecture.id
+								when kyushu_area_id %>
+						<li class="dropdown-item">
+							<%= link_to prefecture.name, prefecture_path(prefecture) %>
+						</li>
+						<% end %>
+						<% end %>
 					</ul>
 				</li>
 			</ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 
 <head>
+  <meta charset="UTF-8">
   <title><%= full_title(yield(:title)) %></title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <%= csrf_meta_tags %>

--- a/app/views/prefectures/index.html.erb
+++ b/app/views/prefectures/index.html.erb
@@ -3,59 +3,80 @@
 	<div class="card mb-4" id="accordionExample">
 		<div class="card-header">
 			<div class="card-body">
-			
+				<!-- 北海道・東北 Link一覧 -->
 				<div class="accordion-button fw-bold" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne"
 					aria-expanded="false" aria-controls="collapseOne">
 					北海道・東北
 				</div>
 				<div id="collapseOne" class="accordion-collapse collapse" aria-labelledby="headingOne"
 					data-bs-parent="#accordionExample">
-					<div class="accordion-body">
-					<ul>
-						<%= hokkaido_tohoku_area_link %>
+					<ul class="accordion-body">
+						<% all_prefectures.each do |prefecture| %>
+						<% case prefecture.id
+								when hokkaido_tohoku_area_id? %>
+						<li>
+							<%= link_to prefecture.name, prefecture_path(prefecture) %>
+						</li>
+						<% end %>
+						<% end %>
 					</ul>
-					</div>
+					</ul>
 				</div>
-
+				<!-- 関東 Link一覧 -->
 				<div class="accordion-button fw-bold" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwo"
 					aria-expanded="false" aria-controls="collapseTwo">
 					関東
 				</div>
 				<div id="collapseTwo" class="accordion-collapse collapse" aria-labelledby="headingTwo"
 					data-bs-parent="#accordionExample">
-					<div class="accordion-body">
-					<ul>
-						<%= kanto_area_link %>
+					<ul class="accordion-body">
+						<% all_prefectures.each do |prefecture| %>
+						<% case prefecture.id
+								when kanto_area_id %>
+						<li>
+							<%= link_to prefecture.name, prefecture_path(prefecture) %>
+						</li>
+						<% end %>
+						<% end %>
 					</ul>
-					</div>
 				</div>
-
+				<!-- 中部 Link一覧 -->
 				<div class="accordion-button fw-bold" type="button" data-bs-toggle="collapse" data-bs-target="#collapseThree"
 					aria-expanded="false" aria-controls="collapseThree">
 					中部
 				</div>
 				<div id="collapseThree" class="accordion-collapse collapse" aria-labelledby="headingThree"
 					data-bs-parent="#accordionExample">
-					<div class="accordion-body">
-					<ul>
-						<%= chubu_area_link %>
+					<ul class="accordion-body">
+						<% all_prefectures.each do |prefecture| %>
+						<% case prefecture.id
+								when chubu_area_id %>
+						<li>
+							<%= link_to prefecture.name, prefecture_path(prefecture) %>
+						</li>
+						<% end %>
+						<% end %>
 					</ul>
-					</div>
 				</div>
-
+				<!-- 近畿 Link一覧 -->
 				<div class="accordion-button fw-bold" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFour"
 					aria-expanded="false" aria-controls="collapseFour">
 					近畿
 				</div>
 				<div id="collapseFour" class="accordion-collapse collapse" aria-labelledby="headingFour"
 					data-bs-parent="#accordionExample">
-					<div class="accordion-body">
-					<ul>
-						<%= kinki_area_link %>
+					<ul class="accordion-body">
+						<% all_prefectures.each do |prefecture| %>
+						<% case prefecture.id
+								when kinki_area_id %>
+						<li>
+							<%= link_to prefecture.name, prefecture_path(prefecture) %>
+						</li>
+						<% end %>
+						<% end %>
 					</ul>
-					</div>
 				</div>
-
+				<!-- 中国 Link一覧 -->
 				<div>
 					<div class="accordion-button fw-bold" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFive"
 						aria-expanded="false" aria-controls="collapseFive">
@@ -64,13 +85,18 @@
 				</div>
 				<div id="collapseFive" class="accordion-collapse collapse" aria-labelledby="headingFive"
 					data-bs-parent="#accordionExample">
-					<div class="accordion-body">
-					<ul>
-						<%= chugoku_area_link %>
+					<ul class="accordion-body">
+						<% all_prefectures.each do |prefecture| %>
+						<% case prefecture.id
+								when chugoku_area_id %>
+						<li>
+							<%= link_to prefecture.name, prefecture_path(prefecture) %>
+						</li>
+						<% end %>
+						<% end %>
 					</ul>
-					</div>
 				</div>
-
+				<!-- 四国 Link一覧 -->
 				<div>
 					<div class="accordion-button fw-bold" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSix"
 						aria-expanded="false" aria-controls="collapseSix">
@@ -79,13 +105,18 @@
 				</div>
 				<div id="collapseSix" class="accordion-collapse collapse" aria-labelledby="headingSix"
 					data-bs-parent="#accordionExample">
-					<div class="accordion-body">
-					<ul>
-						<%= shikoku_area_link %>
+					<ul class="accordion-body">
+						<% all_prefectures.each do |prefecture| %>
+						<% case prefecture.id
+								when shikoku_area_id %>
+						<li>
+							<%= link_to prefecture.name, prefecture_path(prefecture) %>
+						</li>
+						<% end %>
+						<% end %>
 					</ul>
-					</div>
 				</div>
-
+				<!-- 九州・沖縄 Link一覧 -->
 				<div>
 					<div class="accordion-button fw-bold" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSeven"
 						aria-expanded="false" aria-controls="collapseSeven">
@@ -94,11 +125,16 @@
 				</div>
 				<div id="collapseSeven" class="accordion-collapse collapse" aria-labelledby="headingSeven"
 					data-bs-parent="#accordionExample">
-					<div class="accordion-body">
-					<ul>
-						<%= kyushu_area_link %>
+					<ul class="accordion-body">
+						<% all_prefectures.each do |prefecture| %>
+						<% case prefecture.id
+								when kyushu_area_id %>
+						<li>
+							<%= link_to prefecture.name, prefecture_path(prefecture) %>
+						</li>
+						<% end %>
+						<% end %>
 					</ul>
-					</div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
- index, headerの都道府県一覧のリンクのヘルパーを廃止
- `lang="ja"`, `<meta charset="UTF-8">`　追加
close #98 