### PR TITLE
アクセシビリティ修正 #100

### DIFF
--- a/app/views/prefectures/show.html.erb
+++ b/app/views/prefectures/show.html.erb
@@ -19,7 +19,7 @@
 						<tr style="color: <%= weather_color(weather_report)%>">
 							<td class="border-left"><%= l weather_report.dated_on, format: :short %></td>
 							<td class="border-none"><%= weather_report.weather %></td>
-							<td class="border-none"><img src="http://openweathermap.org/img/w/<%=weather_report.weather_icon%>.png">
+							<td class="border-none"><img alt="weather" src="https://openweathermap.org/img/w/<%=weather_report.weather_icon%>.png">
 							</td>
 							<td class="border-right"><%= weather_report.temperature %>℃</td>
 						</tr>

--- a/app/views/shared/_archives.html.erb
+++ b/app/views/shared/_archives.html.erb
@@ -14,7 +14,7 @@
 					<% archives_year.each do |yyyymm, count| %>
 					<button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseYear"
 						aria-expanded="false" aria-controls="collapseYear">
-						<ul　class="m-0">
+						<ul>
 							<li class="fw-bold"><%= ymconv(yyyymm, archives_link.size) %></li>
 						</ul>
 					</button>
@@ -23,14 +23,12 @@
 					<div id="collapseYear" class="accordion-collapse collapse" aria-labelledby="headingYear"
 						data-bs-parent="#accordionExample">
 						<div class="accordion-body">
-							<ul　class="m-0">
+							<ul>
 								<% archives_link.each do |yyyymm, count| %>
-								<li class="p-3">
+								<li>
 									<%= link_to ymconv(yyyymm, count.to_s), prefecture_archive_path(prefecture, yyyymm) %>
 								</li>
-								<hr />
 								<% end %>
-								<hr />
 							</ul>
 						</div>
 					</div>

--- a/spec/features/prefectures_spec.rb
+++ b/spec/features/prefectures_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Prefectures' do
     it 'display weather_icon image' do
       visit prefecture_path city.id
       expect(page).to have_selector(
-        "img[src$='http://openweathermap.org/img/w/#{weather_api.weather_icon}.png']"
+        "img[src$='https://openweathermap.org/img/w/#{weather_api.weather_icon}.png']"
       )
     end
 


### PR DESCRIPTION
- 表示される画像に代替テキストを追加
- 天気アイコンのURLをhttpからhttpsに変更
- app/views/shared/_archives.html.erbの`<ul>`要素の空白が全角になっていた
  - 不要なclassを削除
close #100 