### PR TITLE
アーカイブページのアクセシビリティ修正 #102

### DIFF
--- a/app/views/prefectures/archives.html.erb
+++ b/app/views/prefectures/archives.html.erb
@@ -24,7 +24,7 @@
 						<tr style="color: <%= weather_color(archive)%>">
 							<td class="border-left"><%= l archive.dated_on, format: :short %></td>
 							<td class="border-none"><%= archive.weather %></td>
-							<td class="border-none"><img src="http://openweathermap.org/img/w/<%=archive.weather_icon%>.png">
+							<td class="border-none"><img alt="weather" src="https://openweathermap.org/img/w/<%=archive.weather_icon%>.png">
 							</td>
 							<td class="border-right"><%= archive.temperature %>℃</td>
 						</tr>


### PR DESCRIPTION
- 天気アイコンのURLをhttpからhttpsに変更
- 天気アイコンに代替テキストを追加
close #102 